### PR TITLE
Add movie commentary editing pipeline and tests

### DIFF
--- a/app/services/movie_commentary.py
+++ b/app/services/movie_commentary.py
@@ -1,0 +1,368 @@
+"""Service utilities for producing movie commentary cuts."""
+from __future__ import annotations
+
+import json
+import math
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Union
+from uuid import uuid4
+
+from loguru import logger
+
+from app.config import config
+from app.models.schema import VideoClipParams
+from app.services import task
+from app.services.script_service import ScriptGenerator
+from app.utils import utils
+
+ProgressCallback = Optional[Callable[[float, str], None]]
+ScriptInput = Optional[Union[str, os.PathLike, Sequence[Dict[str, Any]]]]
+
+
+class MovieCommentaryService:
+    """High level orchestration for movie commentary generation."""
+
+    def __init__(self, script_generator: Optional[ScriptGenerator] = None) -> None:
+        self.script_generator = script_generator or ScriptGenerator()
+
+    async def generate_commentary_script(
+        self,
+        video_path: str,
+        *,
+        script: ScriptInput = None,
+        auto_generate: bool = False,
+        video_theme: str = "",
+        custom_prompt: str = "",
+        frame_interval: int = 5,
+        skip_seconds: int = 0,
+        threshold: int = 30,
+        vision_batch_size: int = 5,
+        vision_provider: str = "gemini",
+        script_output_path: Optional[Union[str, os.PathLike]] = None,
+        progress_callback: ProgressCallback = None,
+    ) -> Tuple[List[Dict[str, Any]], str]:
+        """Prepare a normalized commentary script for the given movie."""
+
+        progress = progress_callback or (lambda *_: None)
+
+        if auto_generate or script is None:
+            if not video_path or not os.path.exists(video_path):
+                raise FileNotFoundError(f"视频文件不存在: {video_path}")
+
+            progress(5, "正在自动生成电影解说脚本")
+            script_progress = self._wrap_progress(progress, start=5, span=55)
+            raw_segments = await self.script_generator.generate_script(
+                video_path=video_path,
+                video_theme=video_theme,
+                custom_prompt=custom_prompt,
+                frame_interval_input=frame_interval,
+                skip_seconds=skip_seconds,
+                threshold=threshold,
+                vision_batch_size=vision_batch_size,
+                vision_llm_provider=vision_provider,
+                progress_callback=script_progress,
+            )
+        else:
+            progress(5, "正在加载用户提供的解说脚本")
+            raw_segments = self._load_user_script(script)
+
+        normalized_segments = self._normalize_segments(raw_segments)
+        progress(60, "解说脚本规范化完成")
+
+        script_path = self._save_script(normalized_segments, script_output_path)
+        progress(65, f"脚本已保存: {script_path}")
+
+        return normalized_segments, script_path
+
+    async def generate_commentary_video(
+        self,
+        video_path: str,
+        *,
+        script: ScriptInput = None,
+        auto_generate: bool = False,
+        video_theme: str = "",
+        custom_prompt: str = "",
+        frame_interval: int = 5,
+        skip_seconds: int = 0,
+        threshold: int = 30,
+        vision_batch_size: int = 5,
+        vision_provider: str = "gemini",
+        voice_options: Optional[Dict[str, Any]] = None,
+        subtitle_options: Optional[Dict[str, Any]] = None,
+        mix_options: Optional[Dict[str, Any]] = None,
+        script_output_path: Optional[Union[str, os.PathLike]] = None,
+        task_id: Optional[str] = None,
+        progress_callback: ProgressCallback = None,
+    ) -> Dict[str, Any]:
+        """Generate a movie commentary cut and return metadata about the outputs."""
+
+        if not video_path or not os.path.exists(video_path):
+            raise FileNotFoundError(f"视频文件不存在: {video_path}")
+
+        progress = progress_callback or (lambda *_: None)
+
+        segments, script_path = await self.generate_commentary_script(
+            video_path,
+            script=script,
+            auto_generate=auto_generate,
+            video_theme=video_theme,
+            custom_prompt=custom_prompt,
+            frame_interval=frame_interval,
+            skip_seconds=skip_seconds,
+            threshold=threshold,
+            vision_batch_size=vision_batch_size,
+            vision_provider=vision_provider,
+            script_output_path=script_output_path,
+            progress_callback=progress,
+        )
+
+        params = self._build_video_params(
+            video_path=video_path,
+            script_path=script_path,
+            script_segments=segments,
+            voice_options=voice_options or {},
+            subtitle_options=subtitle_options or {},
+            mix_options=mix_options or {},
+        )
+
+        task_identifier = task_id or str(uuid4())
+        progress(75, "正在裁剪电影片段并匹配解说")
+        result = task.start_subclip_unified(task_identifier, params)
+        progress(100, "电影解说生成完成")
+
+        payload = {
+            "task_id": task_identifier,
+            "script_path": script_path,
+            "script": segments,
+        }
+        if isinstance(result, dict):
+            payload.update(result)
+        return payload
+
+    def _load_user_script(self, script: ScriptInput) -> Sequence[Dict[str, Any]]:
+        if script is None:
+            raise ValueError("未提供解说脚本内容")
+
+        if isinstance(script, (list, tuple)):
+            return list(script)
+
+        if isinstance(script, (str, os.PathLike)):
+            path = Path(script)
+            if path.exists():
+                logger.info(f"加载解说脚本文件: {path}")
+                content = path.read_text(encoding="utf-8")
+            else:
+                content = str(script)
+            cleaned = utils.clean_model_output(content)
+            return json.loads(cleaned)
+
+        raise TypeError("解说脚本必须是JSON文本、文件路径或脚本列表")
+
+    def _normalize_segments(self, segments: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        normalized: List[Dict[str, Any]] = []
+        indexed_segments = list(segments or [])
+        if not indexed_segments:
+            raise ValueError("解说脚本不能为空")
+
+        for index, raw_segment in enumerate(indexed_segments):
+            if not isinstance(raw_segment, dict):
+                raise TypeError("解说脚本片段必须是对象类型")
+
+            start, end, duration, start_seconds = self._normalize_timestamp(raw_segment.get("timestamp"))
+            ost_value = self._coerce_ost(raw_segment.get("OST", 2))
+            narration = (raw_segment.get("narration") or "").strip()
+            if ost_value != 1 and not narration:
+                raise ValueError("非纯原声片段必须包含解说内容")
+
+            picture = raw_segment.get("picture", "")
+            if picture is None:
+                picture = ""
+
+            normalized_segment = dict(raw_segment)
+            normalized_segment["timestamp"] = f"{start}-{end}"
+            normalized_segment["OST"] = ost_value
+            normalized_segment["narration"] = narration
+            normalized_segment.setdefault("picture", picture)
+            normalized_segment["duration"] = round(duration, 3)
+            normalized_segment["_sort_index"] = (start_seconds, index)
+            normalized.append(normalized_segment)
+
+        normalized.sort(key=lambda item: item.pop("_sort_index"))
+        for idx, segment in enumerate(normalized, start=1):
+            segment["_id"] = idx
+        return normalized
+
+    def _normalize_timestamp(self, timestamp: Any) -> Tuple[str, str, float, float]:
+        if not isinstance(timestamp, str) or "-" not in timestamp:
+            raise ValueError("时间戳格式错误，应为 '开始-结束'")
+
+        start_raw, end_raw = timestamp.split("-", 1)
+        start_value = self._normalize_single_timestamp(start_raw)
+        end_value = self._normalize_single_timestamp(end_raw)
+
+        start_seconds = utils.time_to_seconds(start_value)
+        end_seconds = utils.time_to_seconds(end_value)
+        duration = end_seconds - start_seconds
+
+        if not math.isfinite(duration) or duration <= 0:
+            raise ValueError("时间戳范围必须大于0")
+
+        return start_value, end_value, duration, start_seconds
+
+    def _normalize_single_timestamp(self, value: Any) -> str:
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError("时间戳不能为空")
+
+        cleaned = value.strip()
+        sanitized = cleaned.replace("，", ",")
+        components = sanitized.replace(",", ".").split(":")
+
+        try:
+            if len(components) == 3:
+                hours = int(components[0])
+                minutes = int(components[1])
+                seconds = float(components[2])
+            elif len(components) == 2:
+                hours = 0
+                minutes = int(components[0])
+                seconds = float(components[1])
+            elif len(components) == 1:
+                hours = 0
+                minutes = 0
+                seconds = float(components[0])
+            else:
+                raise ValueError
+        except ValueError as exc:
+            raise ValueError("时间戳格式错误") from exc
+
+        if hours < 0 or minutes < 0 or seconds < 0:
+            raise ValueError("时间戳不能为负数")
+
+        total_seconds = hours * 3600 + minutes * 60 + seconds
+        return self._format_seconds(total_seconds)
+
+    def _format_seconds(self, seconds: float) -> str:
+        if seconds < 0:
+            raise ValueError("时间戳不能为负数")
+
+        whole_seconds = int(seconds)
+        milliseconds = int(round((seconds - whole_seconds) * 1000))
+        if milliseconds == 1000:
+            milliseconds = 0
+            whole_seconds += 1
+
+        hours = whole_seconds // 3600
+        minutes = (whole_seconds % 3600) // 60
+        secs = whole_seconds % 60
+
+        return f"{hours:02d}:{minutes:02d}:{secs:02d},{milliseconds:03d}"
+
+    def _coerce_ost(self, value: Any) -> int:
+        if isinstance(value, bool):
+            value = int(value)
+        if isinstance(value, (int, float)):
+            ost = int(value)
+        elif isinstance(value, str):
+            ost = int(value.strip())
+        else:
+            ost = 2
+
+        if ost not in {0, 1, 2}:
+            raise ValueError("OST 字段必须是 0、1 或 2")
+        return ost
+
+    def _build_video_params(
+        self,
+        *,
+        video_path: str,
+        script_path: str,
+        script_segments: List[Dict[str, Any]],
+        voice_options: Dict[str, Any],
+        subtitle_options: Dict[str, Any],
+        mix_options: Dict[str, Any],
+    ) -> VideoClipParams:
+        defaults = VideoClipParams()
+
+        def pick(options: Dict[str, Any], keys: Sequence[str], fallback: Any) -> Any:
+            for key in keys:
+                if key in options and options[key] is not None:
+                    return options[key]
+            return fallback
+
+        subtitle_enabled = pick(subtitle_options, ["enabled", "subtitle_enabled"], defaults.subtitle_enabled)
+        font_name = pick(subtitle_options, ["font_name"], defaults.font_name)
+        font_size = pick(subtitle_options, ["font_size"], defaults.font_size)
+        text_color = pick(subtitle_options, ["color", "text_fore_color"], defaults.text_fore_color)
+        text_background = pick(subtitle_options, ["background", "text_back_color"], defaults.text_back_color)
+        stroke_color = pick(subtitle_options, ["stroke_color"], defaults.stroke_color)
+        stroke_width = pick(subtitle_options, ["stroke_width"], defaults.stroke_width)
+        subtitle_position = pick(subtitle_options, ["position", "subtitle_position"], defaults.subtitle_position)
+        custom_position = pick(subtitle_options, ["custom_position"], defaults.custom_position)
+        threads = pick(subtitle_options, ["threads", "n_threads"], defaults.n_threads)
+
+        voice_name = pick(voice_options, ["voice_name"], defaults.voice_name)
+        voice_volume = pick(voice_options, ["voice_volume"], defaults.voice_volume)
+        voice_rate = pick(voice_options, ["voice_rate"], defaults.voice_rate)
+        voice_pitch = pick(voice_options, ["voice_pitch"], defaults.voice_pitch)
+        tts_engine = pick(voice_options, ["tts_engine"], config.app.get("tts_engine", "edge_tts"))
+
+        tts_volume = pick(mix_options, ["tts_volume"], defaults.tts_volume)
+        original_volume = pick(mix_options, ["original_volume"], defaults.original_volume)
+        bgm_volume = pick(mix_options, ["bgm_volume"], defaults.bgm_volume)
+
+        params = VideoClipParams(
+            video_clip_json=script_segments,
+            video_clip_json_path=str(script_path),
+            video_origin_path=video_path,
+            voice_name=voice_name,
+            voice_volume=voice_volume,
+            voice_rate=voice_rate,
+            voice_pitch=voice_pitch,
+            tts_engine=tts_engine,
+            subtitle_enabled=subtitle_enabled,
+            font_name=font_name,
+            font_size=font_size,
+            text_fore_color=text_color,
+            text_back_color=text_background,
+            stroke_color=stroke_color,
+            stroke_width=stroke_width,
+            subtitle_position=subtitle_position,
+            custom_position=custom_position,
+            n_threads=threads,
+            tts_volume=tts_volume,
+            original_volume=original_volume,
+            bgm_volume=bgm_volume,
+        )
+        return params
+
+    def _save_script(
+        self,
+        segments: List[Dict[str, Any]],
+        script_output_path: Optional[Union[str, os.PathLike]],
+    ) -> str:
+        if script_output_path:
+            target_path = Path(script_output_path)
+        else:
+            base_dir = Path(utils.script_dir("movie_commentary"))
+            timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+            target_path = base_dir / f"movie_commentary_{timestamp}_{uuid4().hex[:8]}.json"
+
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        target_path.write_text(json.dumps(segments, ensure_ascii=False, indent=2), encoding="utf-8")
+        logger.info(f"电影解说脚本已保存: {target_path}")
+        return str(target_path)
+
+    def _wrap_progress(
+        self,
+        callback: Callable[[float, str], None],
+        *,
+        start: float,
+        span: float,
+    ) -> Callable[[float, str], None]:
+        def wrapper(progress: float, message: str) -> None:
+            scaled = start + (span * (progress / 100.0))
+            callback(min(99.0, scaled), message)
+
+        return wrapper

--- a/tests/test_clean_model_output.py
+++ b/tests/test_clean_model_output.py
@@ -1,0 +1,25 @@
+import unittest
+
+from app.utils.utils import clean_model_output
+
+
+class CleanModelOutputTests(unittest.TestCase):
+    def test_removes_markdown_code_fence(self):
+        raw_output = """```json\n{\"message\": \"hello\"}\n```"""
+        self.assertEqual(clean_model_output(raw_output), '{"message": "hello"}')
+
+    def test_preserves_content_without_code_fence(self):
+        raw_output = '{"message": "json`` value"}'
+        self.assertEqual(clean_model_output(raw_output), raw_output)
+
+    def test_handles_non_string_input(self):
+        payload = {"message": "hello"}
+        self.assertIs(clean_model_output(payload), payload)
+
+    def test_case_insensitive_language_hint(self):
+        raw_output = """```JSON\n{\"message\": \"hello\"}\n```"""
+        self.assertEqual(clean_model_output(raw_output), '{"message": "hello"}')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_movie_commentary_service.py
+++ b/tests/test_movie_commentary_service.py
@@ -1,0 +1,159 @@
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+from app.services.movie_commentary import MovieCommentaryService
+
+
+class MovieCommentaryServiceTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.video_path = Path(self.temp_dir.name) / "sample.mp4"
+        self.video_path.write_bytes(b"fake video content")
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    async def test_auto_generate_creates_script_and_invokes_pipeline(self):
+        fake_segments = [
+            {
+                "timestamp": "00:00:00-00:00:05",
+                "narration": "开场介绍",
+                "picture": "Hero walks into frame",
+                "OST": 2,
+            },
+            {
+                "timestamp": "00:00:05-00:00:10",
+                "narration": "情节展开",
+                "picture": "Action intensifies",
+                "OST": 2,
+            },
+        ]
+
+        generator = AsyncMock()
+        generator.generate_script.return_value = fake_segments
+        service = MovieCommentaryService(script_generator=generator)
+
+        voice_options = {
+            "voice_name": "zh-CN-Example",
+            "voice_rate": 1.1,
+            "voice_pitch": 0.9,
+            "tts_engine": "edge_tts",
+        }
+        subtitle_options = {
+            "enabled": True,
+            "font_name": "SimHei",
+            "font_size": 42,
+            "color": "#FFFFFF",
+        }
+        mix_options = {
+            "tts_volume": 1.2,
+            "original_volume": 1.0,
+            "bgm_volume": 0.2,
+        }
+
+        progress_events = []
+
+        def progress(percent, message):
+            progress_events.append((percent, message))
+
+        with patch(
+            "app.services.movie_commentary.utils.script_dir",
+            side_effect=lambda sub_dir="": self.temp_dir.name,
+        ), patch(
+            "app.services.movie_commentary.task.start_subclip_unified",
+            return_value={"videos": ["/tmp/final.mp4"], "combined_videos": ["/tmp/combined.mp4"]},
+        ) as mock_start:
+            result = await service.generate_commentary_video(
+                str(self.video_path),
+                auto_generate=True,
+                video_theme="史诗电影",
+                custom_prompt="突出动作场面",
+                frame_interval=4,
+                skip_seconds=1,
+                threshold=25,
+                vision_batch_size=3,
+                vision_provider="gemini",
+                voice_options=voice_options,
+                subtitle_options=subtitle_options,
+                mix_options=mix_options,
+                progress_callback=progress,
+            )
+
+        generator.generate_script.assert_awaited_once()
+        args, kwargs = generator.generate_script.await_args
+        self.assertEqual(kwargs["video_path"], str(self.video_path))
+        self.assertEqual(kwargs["frame_interval_input"], 4)
+        self.assertEqual(kwargs["vision_batch_size"], 3)
+
+        script_path = Path(result["script_path"])
+        self.assertTrue(script_path.exists())
+        with script_path.open("r", encoding="utf-8") as fh:
+            saved_script = json.load(fh)
+        self.assertEqual(len(saved_script), 2)
+        self.assertEqual(saved_script[0]["_id"], 1)
+        self.assertEqual(saved_script[0]["timestamp"], "00:00:00,000-00:00:05,000")
+        self.assertEqual(saved_script[1]["timestamp"], "00:00:05,000-00:00:10,000")
+
+        mock_start.assert_called_once()
+        _, params = mock_start.call_args[0]
+        self.assertEqual(params.video_clip_json_path, str(script_path))
+        self.assertEqual(params.video_origin_path, str(self.video_path))
+        self.assertEqual(result["videos"], ["/tmp/final.mp4"])
+        self.assertTrue(any(p for p, _ in progress_events if p >= 100))
+
+    async def test_user_script_list_normalization(self):
+        script_input = [
+            {"timestamp": "0:00-0:03", "narration": "第一幕", "OST": "2"},
+            {"timestamp": "00:00:03.5-00:00:06", "narration": "", "OST": 1},
+        ]
+
+        generator = AsyncMock()
+        service = MovieCommentaryService(script_generator=generator)
+
+        with patch(
+            "app.services.movie_commentary.utils.script_dir",
+            side_effect=lambda sub_dir="": self.temp_dir.name,
+        ), patch(
+            "app.services.movie_commentary.task.start_subclip_unified",
+            return_value={"videos": []},
+        ) as mock_start:
+            result = await service.generate_commentary_video(
+                str(self.video_path),
+                script=script_input,
+                voice_options={"tts_engine": "edge_tts"},
+            )
+
+        generator.generate_script.assert_not_called()
+
+        script_path = Path(result["script_path"])
+        with script_path.open("r", encoding="utf-8") as fh:
+            saved_script = json.load(fh)
+
+        self.assertEqual(saved_script[0]["timestamp"], "00:00:00,000-00:00:03,000")
+        self.assertEqual(saved_script[0]["OST"], 2)
+        self.assertEqual(saved_script[1]["timestamp"], "00:00:03,500-00:00:06,000")
+        self.assertEqual(saved_script[1]["OST"], 1)
+        self.assertEqual(saved_script[1]["narration"], "")
+        self.assertEqual([segment["_id"] for segment in saved_script], [1, 2])
+
+        mock_start.assert_called_once()
+        _, params = mock_start.call_args[0]
+        self.assertEqual(params.video_clip_json_path, str(script_path))
+        self.assertEqual(params.video_origin_path, str(self.video_path))
+
+    async def test_requires_script_when_not_auto_generating(self):
+        service = MovieCommentaryService(script_generator=AsyncMock())
+        with self.assertRaises(ValueError):
+            await service.generate_commentary_video(
+                str(self.video_path),
+                auto_generate=False,
+                script=None,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_script_service_gemini.py
+++ b/tests/test_script_service_gemini.py
@@ -1,0 +1,85 @@
+import unittest
+from unittest.mock import patch
+
+from app.config import config
+from app.services.script_service import ScriptGenerator
+
+
+class ProcessWithGeminiTests(unittest.IsolatedAsyncioTestCase):
+    async def test_openai_variant_uses_openai_analyzer(self):
+        generator = ScriptGenerator()
+        fake_frames = [
+            "/tmp/frame_000001_00:00:00,000.jpg",
+            "/tmp/frame_000002_00:00:05,000.jpg",
+            "/tmp/frame_000003_00:00:10,000.jpg",
+        ]
+
+        class DummyAnalyzer:
+            instantiated = False
+
+            def __init__(self, model_name, api_key, base_url):
+                DummyAnalyzer.instantiated = True
+                self.model_name = model_name
+                self.api_key = api_key
+                self.base_url = base_url
+
+            async def analyze_images(self, images, prompt, batch_size):
+                self.images = images
+                self.prompt = prompt
+                self.batch_size = batch_size
+                return [
+                    {"batch_index": 0, "response": "analysis"},
+                ]
+
+        class DummyProcessor:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def process_frames(self, frame_content_list):
+                return frame_content_list
+
+        progress_events = []
+
+        def progress_callback(progress, message):
+            progress_events.append((progress, message))
+
+        with patch.dict(
+            config.app,
+            {
+                "vision_gemini_api_key": "test-key",
+                "vision_gemini_model_name": "test-model",
+                "vision_gemini_base_url": "https://vision.example.com",
+                "vision_analysis_prompt": "describe",
+                "text_llm_provider": "gemini",
+                "text_gemini_api_key": "text-key",
+                "text_gemini_model_name": "gemini-pro",
+                "text_gemini_base_url": "https://text.example.com",
+            },
+            clear=False,
+        ), patch(
+            "app.services.script_service.gemini_analyzer.VisionAnalyzer",
+            side_effect=AssertionError("Should not instantiate VisionAnalyzer"),
+        ), patch(
+            "app.utils.gemini_openai_analyzer.GeminiOpenAIAnalyzer",
+            DummyAnalyzer,
+        ), patch(
+            "app.services.script_service.ScriptProcessor",
+            DummyProcessor,
+        ):
+            result = await generator._process_with_gemini(
+                keyframe_files=fake_frames,
+                video_theme="Adventure",
+                custom_prompt="",
+                vision_batch_size=2,
+                progress_callback=progress_callback,
+                vision_provider="gemini(openai)",
+            )
+
+        self.assertTrue(DummyAnalyzer.instantiated)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["picture"], "analysis")
+        self.assertGreaterEqual(len(progress_events), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a movie commentary service that can auto-generate or normalize user scripts, cut footage, and invoke the unified pipeline
- normalize timestamps, OST flags, and narration fields while saving the script and wiring configurable voice, subtitle, and mix options
- cover the new workflow with async unit tests to ensure generator invocation, script normalization, and error handling

## Testing
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68d2aad982ec83268bc7b798b54c30ae