### PR TITLE
Fix short summary generator function name

### DIFF
--- a/webui/components/script_settings.py
+++ b/webui/components/script_settings.py
@@ -12,7 +12,7 @@ from app.utils import utils, check_script
 from webui.tools.generate_movie_commentary import generate_movie_commentary_script
 from webui.tools.generate_script_docu import generate_script_docu
 from webui.tools.generate_script_short import generate_script_short
-from webui.tools.generate_short_summary import generate_script_short_sunmmary
+from webui.tools.generate_short_summary import generate_script_short_summary
 
 
 def render_script_panel(tr):
@@ -362,7 +362,7 @@ def render_script_buttons(tr, params):
             subtitle_path = st.session_state.get('subtitle_path')
             video_theme = st.session_state.get('video_theme')
             temperature = st.session_state.get('temperature')
-            generate_script_short_sunmmary(params, subtitle_path, video_theme, temperature)
+            generate_script_short_summary(params, subtitle_path, video_theme, temperature)
         else:
             load_script(tr, script_path)
 

--- a/webui/tools/generate_short_summary.py
+++ b/webui/tools/generate_short_summary.py
@@ -134,7 +134,7 @@ def parse_and_fix_json(json_string):
         return None
 
 
-def generate_script_short_sunmmary(params, subtitle_path, video_theme, temperature):
+def generate_script_short_summary(params, subtitle_path, video_theme, temperature):
     """
     生成 短剧解说 视频脚本
     要求: 提供高质量短剧字幕


### PR DESCRIPTION
## Summary
- rename the short summary generation helper to `generate_script_short_summary`
- update the Streamlit component to use the corrected helper name

## Testing
- python -m compileall webui/tools/generate_short_summary.py webui/components/script_settings.py

------
https://chatgpt.com/codex/tasks/task_e_68d7a43881d883268c6950138e24113f