### PR TITLE
Align word count cadence documentation

### DIFF
--- a/app/utils/script_generator.py
+++ b/app/utils/script_generator.py
@@ -506,8 +506,8 @@ class ScriptProcessor:
         
         Returns:
             int: 估算的合适字数
-                  基于经验公式: 每0.35秒可以说一个字
-                  例如: 10秒可以说约28个字 (10/0.35≈28.57)
+                  基于经验公式: 每0.4秒可以说一个字
+                  例如: 10秒可以说约25个字 (10/0.4=25)
         """
         try:
             start_str, end_str = time_range.split('-')
@@ -544,7 +544,7 @@ class ScriptProcessor:
             # 计算持续时间(秒)
             duration = end_seconds - start_seconds
             
-            # 根据经验公式计算字数: 每0.5秒一个字
+            # 根据经验公式计算字数: 每0.4秒一个字
             word_count = int(duration / 0.4)
             
             # 确保字数在合理范围内

--- a/tests/test_script_processor_word_count.py
+++ b/tests/test_script_processor_word_count.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.utils.script_generator import ScriptProcessor
+
+
+@pytest.mark.parametrize(
+    "time_range, expected",
+    [
+        ("00:00:00,000-00:00:10,000", 25),  # 10 秒 -> floor(10/0.4) = 25
+        ("00:00:00,000-00:00:01,500", 10),  # 1.5 秒 -> floor(1.5/0.4)=3, 下限为 10
+        ("00:00:00,000-00:40:00,000", 500),  # 40 分钟 -> 上限为 500
+    ],
+)
+def test_calculate_duration_and_word_count(time_range, expected):
+    processor = ScriptProcessor.__new__(ScriptProcessor)
+
+    assert processor.calculate_duration_and_word_count(time_range) == expected


### PR DESCRIPTION
## Summary
- document the 0.4 second per character cadence used by `calculate_duration_and_word_count`
- clarify the inline comment to match the implemented formula
- add regression tests for the lower, nominal, and upper word-count bounds

## Testing
- pytest tests/test_script_processor_word_count.py

------
https://chatgpt.com/codex/tasks/task_e_68d7a456eb6083269a034f30405865cb