### PR TITLE
Fix script generator import failure caused by corrupted module file

### DIFF
--- a/app/services/movie_commentary.py
+++ b/app/services/movie_commentary.py
@@ -14,7 +14,7 @@ from loguru import logger
 from app.config import config
 from app.models.schema import VideoClipParams
 from app.services import task
-from app.services.script_service import ScriptGenerator
+from app.services.script_generator import ScriptGenerator
 from app.utils import utils
 
 ProgressCallback = Optional[Callable[[float, str], None]]

--- a/app/services/script_generator.py
+++ b/app/services/script_generator.py
@@ -35,7 +35,7 @@ class ScriptGenerator:
             video_theme: 视频主题
             custom_prompt: 自定义提示词
             skip_seconds: 跳过开始的秒数
-            threshold: 差异���值
+            threshold: 差异阈值
             vision_batch_size: 视觉处理批次大小
             vision_llm_provider: 视觉模型提供商
             progress_callback: 进度回调函数

--- a/tests/test_script_generator_gemini.py
+++ b/tests/test_script_generator_gemini.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from app.config import config
-from app.services.script_service import ScriptGenerator
+from app.services.script_generator import ScriptGenerator
 
 
 class ProcessWithGeminiTests(unittest.IsolatedAsyncioTestCase):
@@ -16,7 +16,7 @@ class ProcessWithGeminiTests(unittest.IsolatedAsyncioTestCase):
             captured_kwargs = {}
 
             with patch(
-                "app.services.script_service.video_processor.VideoProcessor"
+                "app.services.script_generator.video_processor.VideoProcessor"
             ) as MockProcessor:
                 instance = MockProcessor.return_value
 
@@ -46,7 +46,7 @@ class ProcessWithGeminiTests(unittest.IsolatedAsyncioTestCase):
             video_path.write_bytes(b"fake video content")
 
             with patch(
-                "app.services.script_service.utils.temp_dir",
+                "app.services.script_generator.utils.temp_dir",
                 return_value=tmp_dir,
             ):
                 generator = ScriptGenerator()
@@ -110,13 +110,13 @@ class ProcessWithGeminiTests(unittest.IsolatedAsyncioTestCase):
             },
             clear=False,
         ), patch(
-            "app.services.script_service.gemini_analyzer.VisionAnalyzer",
+            "app.services.script_generator.gemini_analyzer.VisionAnalyzer",
             side_effect=AssertionError("Should not instantiate VisionAnalyzer"),
         ), patch(
             "app.utils.gemini_openai_analyzer.GeminiOpenAIAnalyzer",
             DummyAnalyzer,
         ), patch(
-            "app.services.script_service.ScriptProcessor",
+            "app.services.script_generator.ScriptProcessor",
             DummyProcessor,
         ):
             result = await generator._process_with_gemini(


### PR DESCRIPTION
## Summary
- rename `app/services/script_service.py` to `app/services/script_generator.py` to replace the corrupted module and keep the script generator implementation intact
- point `MovieCommentaryService` and the Gemini unit tests at the renamed module and refresh the docstring typo while copying the file
- rename the Gemini script generator test module so it mirrors the new service path

## Testing
- PYTHONPATH=. pytest tests/test_script_generator_gemini.py

------
https://chatgpt.com/codex/tasks/task_e_68d88ae7301c8326afce111fcfa228f5