### PR TITLE
Fix pytest import path configuration

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Pytest configuration to ensure project root is importable."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+ROOT_STR = str(ROOT)
+if ROOT_STR not in sys.path:
+    sys.path.insert(0, ROOT_STR)


### PR DESCRIPTION
## Summary
- add a tests-level conftest module to ensure the repository root is on sys.path so the app package can be imported during testing

## Testing
- pytest tests/test_movie_commentary_service.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d890e8da2483269d47cd4167efabf9